### PR TITLE
Fix lorri repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ inside your project.
 ## How It Works
 
 This is a simple, lightweight implementation of Tweag's
-[lorri](https://github.com/target/lorri)
+[lorri](https://github.com/nix-community/lorri)
 
 sorri reuses lorri's tricks for figuring out the files to track for changes,
 but uses direnv's own mechanism for actually tracking those files.


### PR DESCRIPTION
The nix-community repo is where ongoing development is taking place.